### PR TITLE
Point to the legacy endpoint for model configs, for now.

### DIFF
--- a/src/askem_beaker/contexts/mira_config_edit/context.py
+++ b/src/askem_beaker/contexts/mira_config_edit/context.py
@@ -52,7 +52,7 @@ class MiraConfigEditContext(BaseContext):
 
     async def set_model_config(self, item_id, agent=None, parent_header={}):
         self.config_id = item_id
-        meta_url = f"{os.environ['HMI_SERVER_URL']}/model-configurations/{self.config_id}"
+        meta_url = f"{os.environ['HMI_SERVER_URL']}/model-configurations-legacy/{self.config_id}"
         logger.error(f"Meta url: {meta_url}")
         self.configuration = requests.get(meta_url, 
                                           auth=(os.environ['AUTH_USERNAME'],
@@ -115,7 +115,7 @@ class MiraConfigEditContext(BaseContext):
         model_config["configuration"] = new_model
 
         create_req = requests.put(
-            f"{os.environ['HMI_SERVER_URL']}/model-configurations/{self.config_id}", json=model_config,
+            f"{os.environ['HMI_SERVER_URL']}/model-configurations-legacy/{self.config_id}", json=model_config,
                 auth =(os.environ['AUTH_USERNAME'], os.environ['AUTH_PASSWORD'])
         )
 

--- a/src/askem_beaker/contexts/pyciemss/context.py
+++ b/src/askem_beaker/contexts/pyciemss/context.py
@@ -39,7 +39,7 @@ class PyCIEMSSContext(BaseContext):
     async def set_model_config(self, config_id, agent=None, parent_header=None):
         if parent_header is None: parent_header = {}
         self.config_id = config_id
-        meta_url = f"{os.environ['HMI_SERVER_URL']}/model-configurations/{self.config_id}"
+        meta_url = f"{os.environ['HMI_SERVER_URL']}/model-configurations-legacy/{self.config_id}"
         self.configuration = requests.get(meta_url, 
                                           auth=(os.environ['AUTH_USERNAME'],
                                                 os.environ['AUTH_PASSWORD'])


### PR DESCRIPTION
We are currently in the midst of a major refactor on model-configurations and are changing how the endpoints will work. As this system gets integrated we've kept the old model config objects and endpoints active until we're ready to flip the switch.

Note that this PR should not be merged until HMI-Server is updated to use these endpoints correctly: https://github.com/DARPA-ASKEM/terarium/pull/3802