### PR TITLE
Add handler to detect incorrect parameter name

### DIFF
--- a/src/askem_beaker/contexts/mira_config_edit/agent.py
+++ b/src/askem_beaker/contexts/mira_config_edit/agent.py
@@ -13,7 +13,6 @@ from beaker_kernel.lib.jupyter_kernel_proxy import JupyterMessage
 logging.disable(logging.WARNING)  # Disable warnings
 logger = logging.Logger(__name__)
 
-from mira.sources.amr import model_from_json; 
 
 class MiraConfigEditAgent(BaseAgent):
     """
@@ -82,17 +81,16 @@ class MiraConfigEditAgent(BaseAgent):
         """
         # load in model config's parameters to use in comparison to the 
         # user provided parameters to update
-        model_config = model_from_json(agent.context.amr)
-        model_params = model_config.parameters.keys()
+        model_params = agent.context.model_config.parameters.keys()
         user_params = parameter_values['parameter_values'].keys()
 
         # check if any in user_params is not in model_params and return an error
         if not all(param in model_params for param in user_params):
             loop.set_state(loop.STOP_FATAL)
             error_message = f"It looks like you're trying to update parameter(s) that don't exist: " \
-                            f"{', '.join(param for param in user_params if param not in model_params)}." \
+                            f"[{', '.join(param for param in user_params if param not in model_params)}]. " \
                             f"Please ensure you are updating a valid parameter: " \
-                            f"{', '.join(param for param in model_params)}"
+                            f"[{', '.join(param for param in model_params)}]."
             return error_message
 
         loop.set_state(loop.STOP_SUCCESS)

--- a/src/askem_beaker/contexts/mira_config_edit/agent.py
+++ b/src/askem_beaker/contexts/mira_config_edit/agent.py
@@ -13,6 +13,7 @@ from beaker_kernel.lib.jupyter_kernel_proxy import JupyterMessage
 logging.disable(logging.WARNING)  # Disable warnings
 logger = logging.Logger(__name__)
 
+from mira.sources.amr import model_from_json; 
 
 class MiraConfigEditAgent(BaseAgent):
     """
@@ -74,11 +75,26 @@ class MiraConfigEditAgent(BaseAgent):
 
         Please generate the code as if you were programming inside a Jupyter Notebook and the code is to be executed inside a cell.
         You MUST wrap the code with a line containing three backticks (```) before and after the generated code.
-        No addtional text is needed in the response, just the code block.   
+        No addtional text is needed in the response, just the code block.  
 
         Args:
             parameter_values (dict): the dictionary of parameter names and the values to update them with
         """
+        # load in model config's parameters to use in comparison to the 
+        # user provided parameters to update
+        model_config = model_from_json(agent.context.amr)
+        model_params = model_config.parameters.keys()
+        user_params = parameter_values['parameter_values'].keys()
+
+        # check if any in user_params is not in model_params and return an error
+        if not all(param in model_params for param in user_params):
+            loop.set_state(loop.STOP_FATAL)
+            error_message = f"It looks like you're trying to update parameter(s) that don't exist: " \
+                            f"{', '.join(param for param in user_params if param not in model_params)}." \
+                            f"Please ensure you are updating a valid parameter: " \
+                            f"{', '.join(param for param in model_params)}"
+            return error_message
+
         loop.set_state(loop.STOP_SUCCESS)
         code = agent.context.get_code("update_params", {"parameter_values": parameter_values})
         return json.dumps(

--- a/src/askem_beaker/contexts/mira_config_edit/context.py
+++ b/src/askem_beaker/contexts/mira_config_edit/context.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+from mira.sources.amr import model_from_json; 
 
 class MiraConfigEditContext(BaseContext):
 
@@ -64,6 +65,7 @@ class MiraConfigEditContext(BaseContext):
         self.original_amr = copy.deepcopy(self.amr)
         if self.amr:
             await self.load_mira()
+            self.model_config = model_from_json(self.amr)            
         else:
             raise Exception(f"Model config '{item_id}' not found.")
         await self.send_mira_preview_message(parent_header=parent_header)


### PR DESCRIPTION
Resolves https://github.com/DARPA-ASKEM/terarium/issues/3785#event-13102697406 

The issue arose when the user asks an agent to update a parameter that doesn't exist. Instead of notifying the user of the issue, Beaker threw an error.

This PR addresses this by comparing the parameter names supplied by the user against the parameter names in the model before generating the correct parameter update code. If one or more of the parameters that the user supplied do not exist in the model the agent notifies the user. 

![Screenshot 2024-06-10 at 3 59 35 PM](https://github.com/DARPA-ASKEM/askem-beaker/assets/5840199/f8afb767-40cd-4252-a68f-d53a16367a2c)

> **Side Note**: since this loads the model into the Agent's context (not just the user space) we could answer questions about the current parameter/initial condition values without running code...if we wanted to make that update later.