### PR TITLE
Fix: adding gilda dependency for mira

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN git clone https://github.com/indralab/mira.git /home/jupyter/mira && \
     rm -r /home/jupyter/mira
 
 # Install Gilda - Mira Dependency 
-RUN pip install gilda
+RUN pip install gilda==1.2.1
 
 #### START Installs for PySB context
 # Install project requirements

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,9 @@ RUN git clone https://github.com/indralab/mira.git /home/jupyter/mira && \
     pip install --no-cache-dir /home/jupyter/mira/"[ode,tests,dkg-client,sbml]" && \
     rm -r /home/jupyter/mira
 
+# Install Gilda - Mira Dependency 
+RUN pip install gilda
+
 #### START Installs for PySB context
 # Install project requirements
 USER root


### PR DESCRIPTION
Required for some mira code such as importing mira.dkg.web_client
Which is being used for model comparison
https://github.com/DARPA-ASKEM/askem-beaker/blob/653008a8a4e5791a55ee04fd934a7987c2673149/src/askem_beaker/contexts/mira/procedures/python3/compare_mira_models.py#L4


**Testing:**
Open container:
python:
`import mira.dkg.web_client`

prior to update this will fail with an error missing gilda
After this update will be fine