### PR TITLE
add formatter to unlimit output length; comment out image generation …

### DIFF
--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/model_preview.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/model_preview.py
@@ -4,7 +4,11 @@ from mira.modeling.amr.petrinet import template_model_to_petrinet_json
 from mira.modeling.amr.stockflow import template_model_to_stockflow_json
 from mira.modeling.amr.regnet import template_model_to_regnet_json
 
-format_dict, md_dict = InteractiveShell.instance().display_formatter.format(GraphicalModel.for_jupyter(model))
+import IPython
+formatter = IPython.get_ipython().display_formatter.formatters['text/plain']
+formatter.max_seq_length = 0
+
+# format_dict, md_dict = InteractiveShell.instance().display_formatter.format(GraphicalModel.for_jupyter(model))
 
 if "{{ schema_name }}" == "regnet":
     model_json = template_model_to_regnet_json({{ var_name|default("model") }})
@@ -16,8 +20,8 @@ else:
 result = {
     "application/json": model_json
 }
-for key, value in format_dict.items():
-    if "image" in key:
-        result[key] = value
+# for key, value in format_dict.items():
+#     if "image" in key:
+#         result[key] = value
 
 result


### PR DESCRIPTION
### Summary
- Adding `formatter.max_seq_length = 0` per Matt's suggestion to unblock result getting chopped off
- Remove image generation, we are not really using that, and is problematic with large models