### PR TITLE
add robot.jar bootstrap

### DIFF
--- a/Dockerfile.light
+++ b/Dockerfile.light
@@ -59,6 +59,10 @@ COPY --chown=1000:1000 pyproject.toml README.md hatch_build.py /home/jupyter/ask
 RUN mkdir -p /home/jupyter/askem_beaker/src/askem_beaker && touch /home/jupyter/askem_beaker/src/askem_beaker/__init__.py
 RUN pip install --no-cache-dir --upgrade -e /home/jupyter/askem_beaker
 
+# Bootstrap MIRA runtime dependencies, these are lazily downloaded but we will get them ahead of time to avoid quirky
+# interfacing issues across jupyter messaging
+RUN python -c "from pyobo import Term, Reference, Obo"
+
 COPY --chown=1000:1000 . /home/jupyter/askem_beaker/
 
 # Installs the askem specific subkernels


### PR DESCRIPTION
### Summary
A robot.jar  (https://github.com/ontodev/robot) is lazily downloaded when the script is run, this seems to create some weirdness because stderr is streamed back through the jupyter messages and seeming ended up as an error. To avoid this we will just download it ahead of time.


### Testing
- Delete askem-beaker image and rebuild with "make dev"
- Once up, in Terarium do a model-comparison operator and check we get a comparison diagram on the first run