### PR TITLE
Allow agent to inspect model and remove multiple templates

### DIFF
--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/inspect_template_model.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/inspect_template_model.py
@@ -1,0 +1,1 @@
+{{ model_name }}

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/remove_templates.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/remove_templates.py
@@ -1,11 +1,12 @@
-def remove_template(tm: TemplateModel, template_name) -> TemplateModel:
+from typing import List
+def remove_templates(tm: TemplateModel, template_names: List[str]) -> TemplateModel:
 
     # Create new template model,
     # skipping over templates with given names
     tm_new = copy.deepcopy(tm)
     tm_new.templates = []
     for t in tm.templates:
-        if t.name in template_name:
+        if t.name in template_names:
             continue
         tm_new.templates.append(t)
     
@@ -17,4 +18,4 @@ def remove_template(tm: TemplateModel, template_name) -> TemplateModel:
 
     return tm_new
 
-model = remove_template(model, "{{ template_name }}")
+model = remove_templates(model, {{ template_names }})


### PR DESCRIPTION
## What's New

This PR adds three capabilities:

1. `inspect_template_model` tool that allows the agent to run code (behind the scenes) that gives it visibility to the structure of the template model. This can be used to answer questions like: "What are the templates whose subjects end in `diff`?"
2. `generate_code` tool that allows the agent to generate code for doing arbitrary things in response to: "Generate code to produce a list of the templates that end `diff`"
3. `remove_template` -> `remove_templates`: now this takes a `list` of template names to remove which allows users to ask things like "Remove templates from the model if the template subject name beings with `unvaccinated` or ends with `two` or `diff`"

## The Issue

Previously the agent had no ability to inspect the model which is now resolved ✅ . The agent also could not generate code that differed from the pre-defined tools, also solved ✅ . 

However, only `remove_templates` allows for doing multiple things at once--the agent will still not be able to do multiple edits for the other tools unless the tools are updated OR the user modifies the generated code to perform a loop.

## What this Looks like in Practice

Here we can see all the templates at the start of the session:

<img width="1591" alt="Screenshot 2024-09-10 at 11 32 44 AM" src="https://github.com/user-attachments/assets/4c16d216-c5bc-4354-bce6-17c4cce247ed">

Then the user asks for removal of multiple templates based on a set of criteria:

<img width="1583" alt="Screenshot 2024-09-10 at 11 32 50 AM" src="https://github.com/user-attachments/assets/40a22920-f72c-4418-8146-7586ac74bcc6">

The agent uses the `inspect_template_model` tool to determine the templates to exclude then uses the `remove_templates` tool. We can verify success:

<img width="1582" alt="Screenshot 2024-09-10 at 11 32 54 AM" src="https://github.com/user-attachments/assets/e3090fda-8b5f-48d9-84e9-e2e5c6097693">

