### PR TITLE
check dataset description key exist

### DIFF
--- a/src/askem_beaker/contexts/dataset/context.py
+++ b/src/askem_beaker/contexts/dataset/context.py
@@ -234,7 +234,13 @@ Statistics:
         new_dataset = copy.deepcopy(parent_dataset)
         del new_dataset["id"]
         new_dataset["name"] = new_name
-        new_dataset["description"] += f"\\nTransformed from dataset '{parent_dataset['name']}' ({parent_dataset['id']}) at {datetime.datetime.utcnow().strftime('%c %Z')}"
+
+        transformed_info = f"Transformed from dataset '{parent_dataset['name']}' ({parent_dataset['id']}) at {datetime.datetime.utcnow().strftime('%c %Z')}"
+        if "description" in new_dataset:
+            new_dataset["description"] += f"\\n{transformed_info}"
+        else:
+            new_dataset["description"] = transformed_info
+
         new_dataset["fileNames"] = [filename]
         #clear the columns field on the new dataset as there was likely a change to either the columns or the data. HMI-Server will deal with regenerating this.
         new_dataset["columns"] = []


### PR DESCRIPTION
### Summary
"description" may not exist if the dataset are derived from TA3 operations. This PR adds a check guard.


Fixes: https://github.com/DARPA-ASKEM/terarium/issues/4890


### Testing
In terarium with this beaker-instance:
- run simulation
- connect simulation result to dataset transform
- save data frame as a new dataset