### PR TITLE
Add support for adding observables via pattern

### DIFF
--- a/Dockerfile.light
+++ b/Dockerfile.light
@@ -29,7 +29,7 @@ RUN pip install --no-cache-dir git+https://github.com/ciemss/pyciemss.git@adeb6b
 # Install MIRA from GitHub
 RUN git clone https://github.com/indralab/mira.git /home/jupyter/mira
 WORKDIR /home/jupyter/mira
-RUN git reset --hard 3043c9a66e46218645c5d9200c1ca7f028da5b5a
+# RUN git reset --hard 3043c9a66e46218645c5d9200c1ca7f028da5b5a
 RUN pip install --no-cache-dir /home/jupyter/mira/"[ode,tests,dkg-client,dkg-construct,sbml,docs]" && \
     rm -r /home/jupyter/mira
 

--- a/src/askem_beaker/contexts/mira_model_edit/agent.py
+++ b/src/askem_beaker/contexts/mira_model_edit/agent.py
@@ -126,6 +126,46 @@ class MiraModelEditAgent(BaseAgent):
                 "content": code.strip(),
             }
         )
+    
+    @tool()
+    async def add_observable_pattern(self, new_name: str, 
+                                     identifier_keys: list[str], 
+                                     identifier_values: list[str],
+                                     context_keys: list[str],
+                                     context_values: list[str],
+                                     agent: AgentRef, 
+                                     loop: LoopControllerRef):
+        """
+        This tool is used when a user wants to add an observable via a complex pattern. You should inspect the model BEFORE using this tool
+        so that you can properly map the users request to the correct identifiers and contexts in the model. Typically the identifier key
+        will be something like "ido" and the identifier value will be something like "0000514". Context keys will be the name of the strata context (e.g. "Age")
+        and the values will be the value for that strata context (e.g. "youth"). 
+
+        When the user specifies a high level state (such as Infected) this would be specified via the identifiers; when the user specifies 
+        a strata (such as "youth") that is specified via the context.
+
+        Args:
+            new_name (str): The new name provided for the observable. If this is not provided something intuitive should be set.
+            identifier_keys (list[str]): The keys for the identifiers that will be used in the observable.
+            identifier_values (list[str]): The values for the identifiers that will be used in the observable.
+            context_keys (list[str]): The keys for the context that will be used in the observable.
+            context_values (list[str]): The values for the context that will be used in the observable.
+        """
+        code = agent.context.get_code("add_observable_pattern", 
+                                      {"new_name": new_name,
+                                       "identifier_keys": identifier_keys,
+                                       "identifier_values": identifier_values,
+                                       "context_keys": context_keys,
+                                       "context_values": context_values}
+                                      )
+        loop.set_state(loop.STOP_SUCCESS)
+        return json.dumps(
+            {
+                "action": "code_cell",
+                "language": "python3",
+                "content": code.strip(),
+            }
+        )    
 
     @tool()
     async def remove_observable(self, remove_id: str, agent: AgentRef, loop: LoopControllerRef):

--- a/src/askem_beaker/contexts/mira_model_edit/agent.py
+++ b/src/askem_beaker/contexts/mira_model_edit/agent.py
@@ -151,12 +151,16 @@ class MiraModelEditAgent(BaseAgent):
             context_keys (list[str]): The keys for the context that will be used in the observable.
             context_values (list[str]): The values for the context that will be used in the observable.
         """
+        identifier_dict = dict(zip(identifier_keys, identifier_values))
+        context_dict = dict(zip(context_keys, context_values))
         code = agent.context.get_code("add_observable_pattern", 
                                       {"new_name": new_name,
                                        "identifier_keys": identifier_keys,
                                        "identifier_values": identifier_values,
                                        "context_keys": context_keys,
-                                       "context_values": context_values}
+                                       "context_values": context_values,
+                                       "identifier_dict": identifier_dict,
+                                       "context_dict": context_dict}
                                       )
         loop.set_state(loop.STOP_SUCCESS)
         return json.dumps(

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_observable_pattern.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_observable_pattern.py
@@ -1,17 +1,6 @@
-def add_observable_pattern_(new_name, identifier_dict, context_dict):
-    return add_observable_pattern(
-        model,
-        new_name,
-        identifiers = identifier_dict,
-        context = context_dict
+add_observable_pattern(
+    model,
+    "{{ new_name }}",
+    identifiers = {{ identifier_dict }},
+    context = {{ context_dict }}
     )
-
-new_name = "{{ new_name }}"
-identifier_keys = {{ identifier_keys }}
-identifier_values = {{ identifier_values }}
-context_keys = {{ context_keys }}
-context_values = {{ context_values }}
-identifier_dict = dict(zip(identifier_keys, identifier_values))
-context_dict = dict(zip(context_keys, context_values))
-
-add_observable_pattern_(new_name, identifier_dict, context_dict)

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_observable_pattern.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_observable_pattern.py
@@ -1,0 +1,17 @@
+def add_observable_pattern_(new_name, identifier_dict, context_dict):
+    return add_observable_pattern(
+        model,
+        new_name,
+        identifiers = identifier_dict,
+        context = context_dict
+    )
+
+new_name = "{{ new_name }}"
+identifier_keys = {{ identifier_keys }}
+identifier_values = {{ identifier_values }}
+context_keys = {{ context_keys }}
+context_values = {{ context_values }}
+identifier_dict = dict(zip(identifier_keys, identifier_values))
+context_dict = dict(zip(context_keys, context_values))
+
+add_observable_pattern_(new_name, identifier_dict, context_dict)


### PR DESCRIPTION
## What's New

This PR adds a tool to the `mira-model-edit` context for adding observables via a pattern. For a model stratified by `Age` into `[children, adults, elderly]`, and vax status `[vaccinated, unvaccinated]` the user can specify something like:

> *"Can you add an observable called susceptible_vaccinated_children for the susceptible identifier and for vaccinated children?"*

The Agent will then:

1. Inspect the model state to ensure it knows the identifiers for the compartments/strata
2. Generate the appropriate code for adding the observable

## How this was Tested
This was tested by taking an [example SEIRHD model](https://github.com/liunelson/mira/blob/nliu/experiment/notebooks/nliu/data/example_models/seirhd_dist_params.json), stratifying by age and vax status and asking for various permutations of observable addition. 

The results appear to be consistently correct. 

> ~~**CAVEAT**: due to the nature of Archytas (under the hood of Beaker tools) and Jinja templating, the keys and values are specified as lists and are then zipped up in Python. So, the code that is generated uses a custom wrapper around the add observable pattern function. This means the code isn't as explicitly/obvious as I'd like. This is solvable by writing a custom Zip function for Jinja and using that to render the dictionaries directly, instead of having Python zip them. Let me know if this feels important~~ see latest comment, this is resolved!

## Mira version bump
I noticed in the `Dockerfile` we had a hard reset to a specific Mira commit. I removed this so that the version of Mira that is installed would include this new capability. @liunelson I do worry that this version bump of Mira could break other things since I am _unsure why we had that pin in the first place_. See [this line](https://github.com/DARPA-ASKEM/askem-beaker/blob/main/Dockerfile.light#L32) in the Dockerfile.

## Screenshots of this in action

![Screenshot 2024-09-30 at 4 41 24 PM](https://github.com/user-attachments/assets/73b4e7c5-84a0-459a-aae7-a568f5796f8b)
![Screenshot 2024-09-30 at 4 38 47 PM](https://github.com/user-attachments/assets/ab32162c-d7b1-47ee-9721-3587745de94c)


