### PR TITLE
Add plot order to return from model comparison tool

### DIFF
--- a/src/askem_beaker/contexts/mira/agent.py
+++ b/src/askem_beaker/contexts/mira/agent.py
@@ -5,6 +5,7 @@ import io
 import json
 import logging
 import re
+import itertools
 
 from archytas.tool_utils import AgentRef, LoopControllerRef, tool, toolset
 from askem_beaker.contexts.mira.new_base_agent import NewBaseAgent
@@ -78,6 +79,11 @@ class Toolset:
         # handle those cases by extracting the proper field
         if isinstance(model_vars, dict):
             model_vars = list(model_vars.get("model_vars", []))
+        
+        # Generate all possible pairs of models to compare in the order that the plots
+        # will be generated
+        comparison_pairs = [list(pair) for pair in itertools.combinations(model_vars, 2)]
+
         plot_code = agent.context.get_code(
             "compare_mira_models",
             {
@@ -89,6 +95,7 @@ class Toolset:
                 "action": "code_cell",
                 "language": "python3",
                 "content": plot_code.strip(),
+                "plot_order": comparison_pairs
             }
         )
         return result


### PR DESCRIPTION
This PR adds a new output to the return from Beaker for model comparison. In addition to the code that is generated, the JSON response will include `plot_order` which gives you the order in which the comparison plots will be generated.

For example, for `models = ['sir_model', 'SEIRHD_model', 'SEIRHD_model_export']` the response will be:

```
"plot_order": [["sir_model", "SEIRHD_model"], ["sir_model", "SEIRHD_model_export"], ["SEIRHD_model", "SEIRHD_model_export"]]
```