### PR TITLE
Return comparison pairs from comparison code running

### DIFF
--- a/src/askem_beaker/contexts/mira/agent.py
+++ b/src/askem_beaker/contexts/mira/agent.py
@@ -82,7 +82,7 @@ class Toolset:
         
         # Generate all possible pairs of models to compare in the order that the plots
         # will be generated
-        comparison_pairs = [list(pair) for pair in itertools.combinations(model_vars, 2)]
+        agent.context.comparison_pairs = [list(pair) for pair in itertools.combinations(model_vars, 2)]
 
         plot_code = agent.context.get_code(
             "compare_mira_models",
@@ -94,8 +94,7 @@ class Toolset:
             {
                 "action": "code_cell",
                 "language": "python3",
-                "content": plot_code.strip(),
-                "plot_order": comparison_pairs
+                "content": plot_code.strip()
             }
         )
         return result

--- a/src/askem_beaker/contexts/mira/context.py
+++ b/src/askem_beaker/contexts/mira/context.py
@@ -41,6 +41,7 @@ class MiraContext(BaseContext):
         self.variables = {}
         self.imported_modules = {}
         self.few_shot_examples = ""
+        self.comparison_pairs = []
         self.code_blocks = (
             []
         )  # {'code':str,'execution_status':not_executed,executed_successfully,'execution_order':int,'output':output from running code block most recent time.}
@@ -479,3 +480,15 @@ Please answer any user queries or perform user instructions to the best of your 
                 documentation[package] = buf.getvalue()
         print(f"Fetched help for {documentation.keys()}")
         return documentation
+
+
+    @action()
+    async def get_comparison_pairs(self,message):
+        content = {"comparison_pairs": self.comparison_pairs}
+        self.send_response(
+            stream="iopub",
+            msg_or_type="get_comparison_pairs_response",
+            content= content,
+            parent_header=message.header,
+        )
+        return content

--- a/src/askem_beaker/contexts/mira/procedures/python3/compare_mira_models.py
+++ b/src/askem_beaker/contexts/mira/procedures/python3/compare_mira_models.py
@@ -18,3 +18,6 @@ for pair in itertools.combinations(models, 2):
     delta.draw_graph(filename, args="-Grankdir=TB")
     # Display the comparison
     display(Image(filename=filename))
+
+comparison_pairs = [list(pair) for pair in itertools.combinations(models, 2)]
+comparison_pairs


### PR DESCRIPTION
This PR ensures that the code used to generate the comparison images also returns an array of comparison pairs in the proper order. It also add action for fetching comparison pairs called `get_comparison_pairs`. Either can be used to get the pairs of models being compared in each visualization: both return a list of lists of pairs.

For example, if the comparison is `model a`, `model b`, and `model c` then the pairs will be shown as:

```
[['model a', 'model b'], ['model a', 'model c'], ['model b', 'model c']]
```

and the first plot will be for `model a` and `model b`, the 2nd for `model a` and `model c` and so on.