### PR TITLE
pin beaker-kernel to 1.6.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "beaker-kernel>=1.5.3",
+  "beaker-kernel=1.6.8",
   "pandas==1.3.3",
   "matplotlib~=3.7.1",
   "xarray==0.19.0",


### PR DESCRIPTION
[The Beaker update to 1.7.0](https://github.com/jataware/beaker-kernel/pull/82) which is a major change might break things up. So let's pin it for now.

https://unchartedsoftware.slack.com/archives/C049E6PA16V/p1729521849998009