### PR TITLE
Improve the MIRA Edit Model procedures

### DIFF
--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_conversion_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_conversion_template.py
@@ -1,39 +1,41 @@
+# Define state variables
 concepts_name_map = model.get_concepts_name_map()
-if "{{ subject_name }}" not in concepts_name_map:
-    subject_concept = Concept(name = "{{ subject_name }}")
-else:
+initials = {}
+
+if "{{ subject_name }}" in concepts_name_map:
     subject_concept = concepts_name_map.get("{{ subject_name }}")
-
-if "{{ outcome_name }}" not in concepts_name_map:
-    outcome_concept = Concept(name = "{{ outcome_name }}")
 else:
+    subject_concept = Concept(name = "{{ subject_name }}")
+    initials["{{subject_name }}"] = Initial(concept = subject_concept, expression = sympy.Float({{subject_initial_value }}))
+
+if "{{ outcome_name }}" in concepts_name_map:
     outcome_concept = concepts_name_map.get("{{ outcome_name }}")
-
-if "{{controller_name}}" not in concepts_name_map:
-    controller_concept = Concept(name = "{{controller_name}}")
 else:
+    outcome_concept = Concept(name = "{{ outcome_name }}")
+    initials["{{outcome_name }}"] = Initial(concept = outcome_concept, expression = sympy.Float({{outcome_initial_value }}))
+
+if "{{controller_name}}" in concepts_name_map:
     controller_concept = concepts_name_map.get("{{controller_name}}")
+else:
+    controller_concept = Concept(name = "{{controller_name}}")
+    initials["{{controller_name }}"] = Initial(concept = controller_concept, expression = sympy.Float({{controller_initial_value }}))
 
-if "{{ parameter_name}}" not in model.parameters: #note this is checks for paremeter's symbol
-    parameter_unit = Unit(expression = sympy.Symbol("{{ parameter_units}}"))
-    parameters = {
-        "{{ parameter_name}}": Parameter(name = "{{ parameter_name}}", value = {{ parameter_value }}, units = parameter_unit, description = "{{ parameter_description}}")
-    }
+
+# Define parameters
+parameters = {}
+if "{{ parameter_name}}" in model.parameters: #note this is checks for paremeter's symbol
+    parameters["{{ parameter_name}}"] = model.parameters.get("{{ parameter_name}}")
 else: 
-    parameters = {"{{ parameter_name}}": model.parameters.get("{{ parameter_name}}")}
+    parameters["{{ parameter_name}}"] = Parameter(name = "{{ parameter_name}}", value = {{ parameter_value }}, description = "{{ parameter_description}}")
 
-initials = { 
-    "{{subject_name}}": Initial(concept = subject_concept, expression = sympy.Float({{subject_initial_value}})),
-    "{{outcome_name}}": Initial(concept = outcome_concept, expression = sympy.Float({{outcome_initial_value}})),
-    "{{controller_name}}": Initial(concept = controller_concept, expression = sympy.Float({{controller_initial_value}}))
-}
 
+# Add process as new template to the model
 model = model.add_template(
     template = ControlledConversion(
         subject = subject_concept,
         outcome = outcome_concept,
         controller = controller_concept,
-        rate_law = safe_parse_expr("{{ template_expression }}", local_dict=_clash),
+        rate_law = safe_parse_expr("{{ template_expression }}", local_dict = _clash),
         name = "{{ template_name }}"
     ),
     parameter_mapping = parameters,

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_degradation_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_degradation_template.py
@@ -1,32 +1,33 @@
+# Define state variables
 concepts_name_map = model.get_concepts_name_map()
-if "{{ subject_name }}" not in concepts_name_map:
-    subject_concept = Concept(name = "{{ subject_name }}")
-else:
+initials = {}
+if "{{ subject_name }}" in concepts_name_map:
     subject_concept = concepts_name_map.get("{{ subject_name }}")
-
-if "{{controller_name}}" not in concepts_name_map:
-    controller_concept = Concept(name = "{{controller_name}}")
 else:
+    subject_concept = Concept(name = "{{ subject_name }}")
+    initials["{{subject_name }}"] = Initial(concept = outcome_concept, expression = sympy.Float({{subject_initial_value }}))
+
+if "{{controller_name}}" in concepts_name_map:
     controller_concept = concepts_name_map.get("{{controller_name}}")
+else:
+    controller_concept = Concept(name = "{{controller_name}}")
+    initials["{{controller_name }}"] = Initial(concept = controller_concept, expression = sympy.Float({{controller_initial_value }}))
 
-if "{{ parameter_name}}" not in model.parameters: #note this is checks for paremeter's symbol
-    parameter_unit = Unit(expression = sympy.Symbol("{{ parameter_units}}"))
-    parameters = {
-        "{{ parameter_name}}": Parameter(name = "{{ parameter_name}}", value = {{ parameter_value }}, units = parameter_unit, description = "{{ parameter_description}}")
-    }
+
+# Define parameters
+parameters = {}
+if "{{ parameter_name}}" in model.parameters: #note this is checks for paremeter's symbol
+    parameters["{{ parameter_name}}"] = model.parameters.get("{{ parameter_name}}")
 else: 
-    parameters = {"{{ parameter_name}}": model.parameters.get("{{ parameter_name}}")}
+    parameters["{{ parameter_name}}"] = Parameter(name = "{{ parameter_name}}", value = {{ parameter_value }}, description = "{{ parameter_description}}")
 
-initials = { 
-    "{{subject_name }}": Initial(concept = subject_concept, expression = sympy.Float({{subject_initial_value }})),
-    "{{controller_name}}": Initial(concept = controller_concept, expression = sympy.Float({{controller_initial_value }}))
-}
 
+# Add process as new template to the model
 model = model.add_template(
     template = ControlledDegradation(
         subject = subject_concept,
         controller = controller_concept,
-        rate_law = safe_parse_expr("{{ template_expression }}", local_dict=_clash),
+        rate_law = safe_parse_expr("{{ template_expression }}", local_dict = _clash),
         name = "{{ template_name }}"
     ),
     parameter_mapping = parameters,

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_production_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_controlled_production_template.py
@@ -1,32 +1,34 @@
+# Define state variables
 concepts_name_map = model.get_concepts_name_map()
-if "{{ outcome_name }}" not in concepts_name_map:
-    outcome_concept = Concept(name = "{{ outcome_name }}")
-else:
+initials = {}
+
+if "{{ outcome_name }}" in concepts_name_map:
     outcome_concept = concepts_name_map.get("{{ outcome_name }}")
-
-if "{{controller_name}}" not in concepts_name_map:
-    controller_concept = Concept(name = "{{controller_name}}")
 else:
+    outcome_concept = Concept(name = "{{ outcome_name }}")
+    initials["{{outcome_name }}"] = Initial(concept = outcome_concept, expression = sympy.Float({{outcome_initial_value }}))
+
+if "{{controller_name}}" in concepts_name_map:
     controller_concept = concepts_name_map.get("{{controller_name}}")
+else:
+    controller_concept = Concept(name = "{{controller_name}}")
+    initials["{{controller_name }}"] = Initial(concept = controller_concept, expression = sympy.Float({{controller_initial_value }}))
 
-if "{{ parameter_name}}" not in model.parameters: #note this is checks for paremeter's symbol
-    parameter_unit = Unit(expression = sympy.Symbol("{{ parameter_units}}"))
-    parameters = {
-        "{{ parameter_name}}": Parameter(name = "{{ parameter_name}}", value = {{ parameter_value }}, units = parameter_unit, description = "{{ parameter_description}}")
-    }
+
+# Define parameters
+parameters = {}
+if "{{ parameter_name}}" in model.parameters: #note this is checks for paremeter's symbol
+    parameters["{{ parameter_name}}"] = model.parameters.get("{{ parameter_name}}")
 else: 
-    parameters = {"{{ parameter_name}}": model.parameters.get("{{ parameter_name}}")}
+    parameters["{{ parameter_name}}"] = Parameter(name = "{{ parameter_name}}", value = {{ parameter_value }}, description = "{{ parameter_description}}")
 
-initials = { 
-    "{{outcome_name}}": Initial(concept = outcome_concept, expression = sympy.Float({{outcome_initial_value }})),
-    "{{controller_name }}": Initial(concept = controller_concept, expression = sympy.Float({{controller_initial_value }}))
-}
 
+# Add process as new template to the model
 model = model.add_template(
     template = ControlledProduction(
         outcome = outcome_concept,
         controller = controller_concept,
-        rate_law = safe_parse_expr("{{ template_expression }}", local_dict=_clash),
+        rate_law = safe_parse_expr("{{ template_expression }}", local_dict = _clash),
         name = "{{ template_name }}"
     ),
     parameter_mapping = parameters,

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_conversion_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_conversion_template.py
@@ -1,32 +1,34 @@
+# Define state variables
 concepts_name_map = model.get_concepts_name_map()
-if "{{ subject_name }}" not in concepts_name_map:
-    subject_concept = Concept(name = "{{ subject_name }}")
-else:
+initials = {}
+
+if "{{ subject_name }}" in concepts_name_map:
     subject_concept = concepts_name_map.get("{{ subject_name }}")
-
-if "{{ outcome_name }}" not in concepts_name_map:
-    outcome_concept = Concept(name = "{{ outcome_name }}")
 else:
+    subject_concept = Concept(name = "{{ subject_name }}")
+    initials["{{subject_name }}"] = Initial(concept = subject_concept, expression = sympy.Float({{subject_initial_value }}))
+
+if "{{ outcome_name }}" in concepts_name_map:
     outcome_concept = concepts_name_map.get("{{ outcome_name }}")
+else:
+    outcome_concept = Concept(name = "{{ outcome_name }}")
+    initials["{{outcome_name }}"] = Initial(concept = outcome_concept, expression = sympy.Float({{outcome_initial_value }}))
 
-if "{{ parameter_name}}" not in model.parameters: #note this is checks for paremeter's symbol
-    parameter_unit = Unit(expression = sympy.Symbol("{{ parameter_units}}"))
-    parameters = {
-        "{{ parameter_name}}": Parameter(name = "{{ parameter_name}}", value = {{ parameter_value }}, units = parameter_unit, description = "{{ parameter_description}}")
-    }
+
+# Define parameters
+parameters = {}
+if "{{ parameter_name}}" in model.parameters: #note this is checks for paremeter's symbol
+    parameters["{{ parameter_name}}"] = model.parameters.get("{{ parameter_name}}")
 else: 
-    parameters = {"{{ parameter_name}}": model.parameters.get("{{ parameter_name}}")}
+    parameters["{{ parameter_name}}"] = Parameter(name = "{{ parameter_name}}", value = {{ parameter_value }}, description = "{{ parameter_description}}")
 
-initials = { 
-    "{{subject_name }}": Initial(concept = subject_concept, expression = sympy.Float({{subject_initial_value }})),
-    "{{outcome_name }}": Initial(concept = outcome_concept, expression = sympy.Float({{outcome_initial_value }}))
-}
 
+# Add process as new template to the model
 model = model.add_template(
     template = NaturalConversion(
         subject = subject_concept,
         outcome = outcome_concept,
-        rate_law = safe_parse_expr("{{ template_expression }}", local_dict=_clash),
+        rate_law = safe_parse_expr("{{ template_expression }}", local_dict = _clash),
         name = "{{ template_name }}"
     ),
     parameter_mapping = parameters,

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_degradation_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_degradation_template.py
@@ -1,25 +1,24 @@
+# Define state variables
 concepts_name_map = model.get_concepts_name_map()
-if "{{ subject_name }}" not in concepts_name_map:
-    subject_concept = Concept(name = "{{ subject_name }}")
-else:
+initials = {}
+if "{{ subject_name }}" in concepts_name_map:
     subject_concept = concepts_name_map.get("{{ subject_name }}")
+else:
+    subject_concept = Concept(name = "{{ subject_name }}")
+    initials["{{subject_name }}"] = Initial(concept = outcome_concept, expression = sympy.Float({{subject_initial_value }}))
 
-if "{{ parameter_name}}" not in model.parameters: #note this is checks for paremeter's symbol
-    parameter_unit = Unit(expression = sympy.Symbol("{{ parameter_units}}"))
-    parameters = {
-        "{{ parameter_name}}": Parameter(name = "{{ parameter_name}}", value = {{ parameter_value }}, units = parameter_unit, description = "{{ parameter_description}}")
-    }
+# Define parameters
+parameters = {}
+if "{{ parameter_name}}" in model.parameters: #note this is checks for paremeter's symbol
+    parameters["{{ parameter_name}}"] = model.parameters.get("{{ parameter_name}}")
 else: 
-    parameters = {"{{ parameter_name}}": model.parameters.get("{{ parameter_name}}")}
+    parameters["{{ parameter_name}}"] = Parameter(name = "{{ parameter_name}}", value = {{ parameter_value }}, description = "{{ parameter_description}}")
 
-initials = { 
-    "{{subject_name }}": Initial(concept = subject_concept, expression = sympy.Float({{subject_initial_value }}))
-}
-
+# Add process as new template to the model
 model = model.add_template(
     template = NaturalDegradation(
         subject = subject_concept,
-        rate_law = safe_parse_expr("{{ template_expression }}", local_dict=_clash),
+        rate_law = safe_parse_expr("{{ template_expression }}", local_dict = _clash),
         name = "{{ template_name }}"
     ),
     parameter_mapping = parameters,

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_production_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_natural_production_template.py
@@ -1,25 +1,26 @@
+# Define state variables
 concepts_name_map = model.get_concepts_name_map()
-if "{{ outcome_name }}" not in concepts_name_map:
-    outcome_concept = Concept(name = "{{ outcome_name }}")
-else:
+initials = {}
+if "{{ outcome_name }}" in concepts_name_map:
     outcome_concept = concepts_name_map.get("{{ outcome_name }}")
+else:
+    outcome_concept = Concept(name = "{{ outcome_name }}")
+    initials["{{outcome_name }}"] = Initial(concept = outcome_concept, expression = sympy.Float({{outcome_initial_value }}))
 
-if "{{ parameter_name}}" not in model.parameters: #note this is checks for paremeter's symbol
-    parameter_unit = Unit(expression = sympy.Symbol("{{ parameter_units}}"))
-    parameters = {
-        "{{ parameter_name}}": Parameter(name = "{{ parameter_name}}", value = {{ parameter_value }}, units = parameter_unit, description = "{{ parameter_description}}")
-    }
+
+# Define parameters
+parameters = {}
+if "{{ parameter_name}}" in model.parameters: #note this is checks for paremeter's symbol
+    parameters["{{ parameter_name}}"] = model.parameters.get("{{ parameter_name}}")
 else: 
-    parameters = {"{{ parameter_name}}": model.parameters.get("{{ parameter_name}}")}
+    parameters["{{ parameter_name}}"] = Parameter(name = "{{ parameter_name}}", value = {{ parameter_value }}, description = "{{ parameter_description}}")
 
-initials = { 
-    "{{outcome_name }}": Initial(concept = outcome_concept, expression = sympy.Float({{outcome_initial_value }}))
-}
 
+# Add process as new template to the model
 model = model.add_template(
     template = NaturalProduction(
         outcome = outcome_concept,
-        rate_law = safe_parse_expr("{{ template_expression }}", local_dict=_clash),
+        rate_law = safe_parse_expr("{{ template_expression }}", local_dict = _clash),
         name = "{{ template_name }}"
     ),
     parameter_mapping = parameters,


### PR DESCRIPTION
* Removed parameter unit to avoid MIRA error when `""` is given as parameter unit
* Removed `initials` definition when the concept exists already (assuming existing concepts have initials already)