### PR TITLE
Add group controlled

### DIFF
--- a/src/askem_beaker/contexts/mira_model_edit/agent.py
+++ b/src/askem_beaker/contexts/mira_model_edit/agent.py
@@ -969,7 +969,7 @@ class MiraModelEditAgent(BaseAgent):
         )
 
     @tool()
-    async def add_controlled_production_template(self,
+    async def add_group_controlled_production_template(self,
         outcome_name: str,
         outcome_initial_value: float,
         controller_names: list[str],
@@ -981,7 +981,7 @@ class MiraModelEditAgent(BaseAgent):
         template_name: str,
         agent: AgentRef, loop: LoopControllerRef):
         """
-        This tool is used when a user wants to add a controlled production to the model.
+        This tool is used when a user wants to add a group controlled production to the model.
         A group controlled production is a template that contains two concepts or state variables: 
           - the outcome represents a population that grows due to this transition
           - the controller represents a group of populations upon which the growth rate depends

--- a/src/askem_beaker/contexts/mira_model_edit/agent.py
+++ b/src/askem_beaker/contexts/mira_model_edit/agent.py
@@ -843,7 +843,7 @@ class MiraModelEditAgent(BaseAgent):
         )
 
     @tool()
-    async def add_grouped_controlled_degradation_template(self,
+    async def add_group_controlled_degradation_template(self,
         subject_name: str,
         subject_initial_value: float,
         controller_names: list[str],
@@ -886,7 +886,7 @@ class MiraModelEditAgent(BaseAgent):
             template_name (str): the name of the transition.
         """
 
-        code = agent.context.get_code("add_grouped_controlled_degradation_template", {
+        code = agent.context.get_code("add_group_controlled_degradation_template", {
             "subject_name": subject_name,
             "subject_initial_value": subject_initial_value,
             "controller_names": controller_names,
@@ -907,7 +907,7 @@ class MiraModelEditAgent(BaseAgent):
         )
 
     @tool()
-    async def add_grouped_controlled_conversion_template(self,
+    async def add_group_controlled_conversion_template(self,
         subject_name: str,
         subject_initial_value: float,
         outcome_name: str,
@@ -946,7 +946,7 @@ class MiraModelEditAgent(BaseAgent):
             template_name (str): the name of the transition.
         """
 
-        code = agent.context.get_code("add_grouped_controlled_conversion_template", {
+        code = agent.context.get_code("add_group_controlled_conversion_template", {
             "subject_name": subject_name,
             "subject_initial_value": subject_initial_value,
             "outcome_name": outcome_name,
@@ -1010,7 +1010,7 @@ class MiraModelEditAgent(BaseAgent):
             template_name (str): the name of the transition.
         """
 
-        code = agent.context.get_code("add_grouped_controlled_production_template", {
+        code = agent.context.get_code("add_group_controlled_production_template", {
             "outcome_name": outcome_name,
             "outcome_initial_value": outcome_initial_value,
             "controller_names": controller_names,

--- a/src/askem_beaker/contexts/mira_model_edit/agent.py
+++ b/src/askem_beaker/contexts/mira_model_edit/agent.py
@@ -841,7 +841,197 @@ class MiraModelEditAgent(BaseAgent):
                 "content": code.strip() + "\n\n\n\n\n" + code2.strip(),
             }
         )
-    
+
+    @tool()
+    async def add_grouped_controlled_degradation_template(self,
+        subject_name: str,
+        subject_initial_value: float,
+        controller_names: list[str],
+        parameter_name: str,
+        parameter_units: str,
+        parameter_value: float,
+        parameter_description: str,
+        template_expression: str,
+        template_name: str,
+        agent: AgentRef, loop: LoopControllerRef):
+        """
+        This tool is used when a user wants to add a grouped controlled degradation to the model.
+        A grouped controlled degradation transition is similar to the natural degradation transition:
+          - it only has a subject
+          - it has no outcome
+          - it does have a list of controllers
+
+        An example of a grouped controlled degradation transition is predation or the decrease of a prey population caused by a predator population
+          - the user request could be "add a death process to the 'Rabbit' caused by 'Wolf', and 'Owl' 
+          - template_name = "Death of Rabbits caused by Wolf"
+          - template_expression = "beta * Rabbit * Wolf"
+          - subject_name = "Rabbit"
+          - controller_names = ["Wolf", "Owl"]
+          - parameter_name = "beta"
+          - parameter_value = "0.01"
+
+        Always make sure that template_expression is the string representation of a mathematical expression that can be parsed by SymPy.
+        If the user provides a math expression containing the operator "^", replace it with "**".
+        If the user provides an equation, pick the right hand side expression
+        
+        Args:
+            subject_name (str): the state names that is the new transition's outputs. This is the state population moves to.
+            subject_initial_value (float): The number associated with the output state at its first step in time. If not known or not specified the default value of `1` should be used.
+            controller_names (list[str]): The names of the controller states. These are the states that will impact the transition's rate.
+            parameter_name (str): the name of the parameter.
+            parameter_units (str): The units associated with the parameter.
+            parameter_value (float): This is a numeric value provided by the user. If not known or not specified the default value of `1` should be used.
+            parameter_description (str): The description associated with the parameter. If not known or not specified the default value of `` should be used
+            template_expression (str): The mathematical rate law for the transition.
+            template_name (str): the name of the transition.
+        """
+
+        code = agent.context.get_code("add_grouped_controlled_degradation_template", {
+            "subject_name": subject_name,
+            "subject_initial_value": subject_initial_value,
+            "controller_names": controller_names,
+            "parameter_name": parameter_name,
+            "parameter_units": parameter_units,
+            "parameter_value": parameter_value,
+            "parameter_description": parameter_description,
+            "template_expression": template_expression,
+            "template_name": template_name
+        })
+        loop.set_state(loop.STOP_SUCCESS)
+        return json.dumps(
+            {
+                "action": "code_cell",
+                "language": "python3",
+                "content": code.strip(),
+            }
+        )
+
+    @tool()
+    async def add_grouped_controlled_conversion_template(self,
+        subject_name: str,
+        subject_initial_value: float,
+        outcome_name: str,
+        outcome_initial_value: float,
+        controller_names: list[str],
+        parameter_name: str,
+        parameter_units: str,
+        parameter_value: float,
+        parameter_description: str,
+        template_expression: str,
+        template_name: str,
+        agent: AgentRef, loop: LoopControllerRef):
+        """
+        This tool is used when a user wants to add a grouped controlled conversion to the model.
+        A grouped controlled conversion is a template that contains two states and a transition where one state is sending population to the transition and one state is receiving population from the transition.
+        This transition rate depends on a controller state. This controller state can be an existing or new state in the model.
+
+        An example of this would be "Add a new transition from S to R with the name vaccine with the rate of v. v depends on I and S"
+        Where S is the subject state, R is the outcome state, vaccine is the template_name, and v is the template_expression and ["I","S"] are the controller_names.
+
+        Always make sure that template_expression is the string representation of a mathematical expression that can be parsed by SymPy.
+        If the user provides a math expression containing the operator "^", replace it with "**".
+        If the user provides an equation, pick the right hand side expression.
+
+        Args:
+            subject_name (str): The state name that is the source of the new transition. This is the state population comes from.
+            subject_initial_value (float): The number associated with the subject state at its first step in time. If not known or not specified the default value of `1` should be used.
+            outcome_name (str): the state name that is the new transition's outputs. This is the state population moves to.
+            outcome_initial_value (float): The number associated with the output state at its first step in time. If not known or not specified the default value of `1` should be used.
+            controller_names (list[str]): The names of the controller states. These are the states that will impact the transition's rate.
+            parameter_name (str): the name of the parameter.
+            parameter_units (str): The units associated with the parameter.
+            parameter_value (float): This is a numeric value provided by the user. If not known or not specified the default value of `1` should be used.
+            parameter_description (str): The description associated with the parameter. If not known or not specified the default value of `` should be used
+            template_expression (str): The mathematical rate law for the transition.
+            template_name (str): the name of the transition.
+        """
+
+        code = agent.context.get_code("add_grouped_controlled_conversion_template", {
+            "subject_name": subject_name,
+            "subject_initial_value": subject_initial_value,
+            "outcome_name": outcome_name,
+            "outcome_initial_value": outcome_initial_value,
+            "controller_names": controller_names,
+            "parameter_name": parameter_name,
+            "parameter_units": parameter_units,
+            "parameter_value": parameter_value,
+            "parameter_description": parameter_description,
+            "template_expression": template_expression,
+            "template_name": template_name
+        })
+        loop.set_state(loop.STOP_SUCCESS)
+        return json.dumps(
+            {
+                "action": "code_cell",
+                "language": "python3",
+                "content": code.strip(),
+            }
+        )
+
+    @tool()
+    async def add_controlled_production_template(self,
+        outcome_name: str,
+        outcome_initial_value: float,
+        controller_names: list[str],
+        parameter_name: str,
+        parameter_units: str,
+        parameter_value: float,
+        parameter_description: str,
+        template_expression: str,
+        template_name: str,
+        agent: AgentRef, loop: LoopControllerRef):
+        """
+        This tool is used when a user wants to add a controlled production to the model.
+        A group controlled production is a template that contains two concepts or state variables: 
+          - the outcome represents a population that grows due to this transition
+          - the controller represents a group of populations upon which the growth rate depends
+
+        An example of a group controlled production transition is to model the cumulative sum of a population over time:
+          - The user request could be "create a cumulative sum of the state variables 'Infected' and 'Recovered'. Name it 'cumulativeSum"
+          - outcome_name = "cumulativeSum"
+          - controller_names = ["Infected", "Recovered"]
+          - template_name = "cumulativeSum"
+          - there is no parameter
+          - template_expression = "Infected + Recovered"
+
+        Always make sure that template_expression is the string representation of a mathematical expression that can be parsed by SymPy.
+        If the user provides a math expression containing the operator "^", replace it with "**".
+        If the user provides an equation, pick the right hand side expression.
+
+        Args:
+            outcome_name (str): the name of the concept that is the outcome of the new transition.
+            outcome_initial_value (float): The number associated with the output state at its first step in time. If not known or not specified the default value of `1` should be used.
+            controller_names (list[str]): The names of the controller states. These are the states that will impact the transition's rate.
+            parameter_name (str): the name of the parameter.
+            parameter_units (str): The units associated with the parameter.
+            parameter_value (float): This is a numeric value provided by the user. If unknown or unspecified, the default value of `1` should be used.
+            parameter_description (str): The description associated with the parameter. If unknown or unspecified, the default value of `` should be used
+            template_expression (str): The mathematical rate law for the transition.
+            template_name (str): the name of the transition.
+        """
+
+        code = agent.context.get_code("add_grouped_controlled_production_template", {
+            "outcome_name": outcome_name,
+            "outcome_initial_value": outcome_initial_value,
+            "controller_names": controller_names,
+            "parameter_name": parameter_name,
+            "parameter_units": parameter_units,
+            "parameter_value": parameter_value,
+            "parameter_description": parameter_description,
+            "template_expression": template_expression,
+            "template_name": template_name
+        })
+        loop.set_state(loop.STOP_SUCCESS)
+        return json.dumps(
+            {
+                "action": "code_cell",
+                "language": "python3",
+                "content": code.strip(),
+            }
+        )
+
+ 
+
     @tool()
     async def generate_code(
         self, query: str, agent: AgentRef, loop: LoopControllerRef

--- a/src/askem_beaker/contexts/mira_model_edit/context.py
+++ b/src/askem_beaker/contexts/mira_model_edit/context.py
@@ -574,3 +574,116 @@ class MiraModelEditContext(BaseContext):
 		    "iopub", "stratify_response", content, parent_header=message.header
 		)
 		await self.send_mira_preview_message(parent_header=message.header)
+
+    @intercept()
+	async def add_group_controlled_conversion_template_request(self, message):
+		content = message.content
+
+		subject_name  = content.get("subject_name")
+		subject_initial_value = content.get("subject_initial_value")
+		outcome_name  = content.get("outcome_name")
+		outcome_initial_value = content.get("outcome_initial_value")
+		controller_names = content.get("controller_names")
+		parameter_name = content.get("parameter_name")
+		parameter_value = content.get("parameter_value")
+		parameter_units = content.get("parameter_units")
+		parameter_description = content.get("parameter_description")
+		template_expression = content.get("template_expression")
+		template_name = content.get("template_name")
+
+		code = self.get_code("add_group_controlled_conversion_template", {
+			"subject_name": subject_name,
+			"subject_initial_value": subject_initial_value,
+			"outcome_name": outcome_name,
+			"outcome_initial_value": outcome_initial_value,
+			"controller_names": controller_names,
+			"parameter_name": parameter_name,
+			"parameter_value": parameter_value,
+			"parameter_units": parameter_units,
+			"parameter_description": parameter_description,
+			"template_expression": template_expression,
+			"template_name": template_name
+		})
+		result = await self.execute(code)
+		content = {
+			"success": True,
+			"executed_code": result["parent"].content["code"],
+		}
+
+		self.beaker_kernel.send_response(
+			"iopub", "add_group_controlled_conversion_template_response", content, parent_header=message.header
+		)
+		await self.send_mira_preview_message(parent_header=message.header)
+
+	@intercept()
+	async def add_group_controlled_production_template_request(self, message):
+		content = message.content
+
+		outcome_name  = content.get("outcome_name")
+		outcome_initial_value = content.get("outcome_initial_value")
+		controller_names = content.get("controller_names")
+		parameter_name = content.get("parameter_name")
+		parameter_value = content.get("parameter_value")
+		parameter_units = content.get("parameter_units")
+		parameter_description = content.get("parameter_description")
+		template_expression = content.get("template_expression")
+		template_name = content.get("template_name")
+
+		code = self.get_code("add_group_controlled_production_template", {
+			"outcome_name": outcome_name,
+			"outcome_initial_value": outcome_initial_value,
+			"controller_names": controller_names,
+			"parameter_name": parameter_name,
+			"parameter_value": parameter_value,
+			"parameter_units": parameter_units,
+			"parameter_description": parameter_description,
+			"template_expression": template_expression,
+			"template_name": template_name
+		})
+		result = await self.execute(code)
+		content = {
+			"success": True,
+			"executed_code": result["parent"].content["code"],
+		}
+
+		self.beaker_kernel.send_response(
+			"iopub", "add_group_controlled_production_template_response", content, parent_header=message.header
+		)
+		await self.send_mira_preview_message(parent_header=message.header)
+
+	@intercept()
+	async def add_group_controlled_degradation_template_request(self, message):
+		content = message.content
+
+		subject_name  = content.get("subject_name")
+		subject_initial_value = content.get("subject_initial_value")
+		controller_names = content.get("controller_names")
+		parameter_name = content.get("parameter_name")
+		parameter_value = content.get("parameter_value")
+		parameter_units = content.get("parameter_units")
+		parameter_description = content.get("parameter_description")
+		template_expression = content.get("template_expression")
+		template_name = content.get("template_name")
+
+		code = self.get_code("add_group_controlled_degradation_template", {
+			"subject_name": subject_name,
+			"subject_initial_value": subject_initial_value,
+			"controller_name": controller_names,
+			"parameter_name": parameter_name,
+			"parameter_value": parameter_value,
+			"parameter_units": parameter_units,
+			"parameter_description": parameter_description,
+			"template_expression": template_expression,
+			"template_name": template_name
+		})
+		result = await self.execute(code)
+		content = {
+			"success": True,
+			"executed_code": result["parent"].content["code"],
+		}
+
+		self.beaker_kernel.send_response(
+			"iopub", "add_group_controlled_degradation_template_response", content, parent_header=message.header
+		)
+		await self.send_mira_preview_message(parent_header=message.header)
+

--- a/src/askem_beaker/contexts/mira_model_edit/context.py
+++ b/src/askem_beaker/contexts/mira_model_edit/context.py
@@ -15,8 +15,8 @@ from .agent import MiraModelEditAgent
 from askem_beaker.utils import get_auth
 
 if TYPE_CHECKING:
-    from beaker_kernel.kernel import LLMKernel
-    from beaker_kernel.lib.subkernels.base import BaseSubkernel
+	from beaker_kernel.kernel import LLMKernel
+	from beaker_kernel.lib.subkernels.base import BaseSubkernel
 
 logger = logging.getLogger(__name__)
 
@@ -554,28 +554,28 @@ class MiraModelEditContext(BaseContext):
 		structure = content.get("structure")
 
 		stratify_code = self.get_code("stratify", {
-		    "key": key,
-		    "strata": strata,
-		    "concepts_to_stratify": concepts_to_stratify,
-		    "concepts_to_preserve": concepts_to_preserve,
-		    "params_to_stratify": params_to_stratify,
-		    "params_to_preserve": params_to_preserve,
-		    "cartesian_control": cartesian_control,
-		    "structure": structure
+			"key": key,
+			"strata": strata,
+			"concepts_to_stratify": concepts_to_stratify,
+			"concepts_to_preserve": concepts_to_preserve,
+			"params_to_stratify": params_to_stratify,
+			"params_to_preserve": params_to_preserve,
+			"cartesian_control": cartesian_control,
+			"structure": structure
 		})
 		stratify_result = await self.execute(stratify_code)
 
 		content = {
-		    "success": True,
-		    "executed_code": stratify_result["parent"].content["code"],
+			"success": True,
+			"executed_code": stratify_result["parent"].content["code"],
 		}
 
 		self.beaker_kernel.send_response(
-		    "iopub", "stratify_response", content, parent_header=message.header
+			"iopub", "stratify_response", content, parent_header=message.header
 		)
 		await self.send_mira_preview_message(parent_header=message.header)
 
-    @intercept()
+	@intercept()
 	async def add_group_controlled_conversion_template_request(self, message):
 		content = message.content
 

--- a/src/askem_beaker/contexts/mira_model_edit/context.py
+++ b/src/askem_beaker/contexts/mira_model_edit/context.py
@@ -35,7 +35,7 @@ class MiraModelEditContext(BaseContext):
 		self.reset()
 		self.auth = get_auth()
 		super().__init__(beaker_kernel, self.agent_cls, config)
-    
+
 	async def setup(self, context_info, parent_header):
 		logger.debug(f"performing setup...")
 		self.context_info = context_info
@@ -55,7 +55,7 @@ class MiraModelEditContext(BaseContext):
 			self.config_id = "default"
 			meta_url = f"{os.environ['HMI_SERVER_URL']}/models/{self.model_id}"
 			self.amr = requests.get(meta_url, auth=self.auth.requests_auth()).json()
-			self.schema_name = self.amr.get("header",{}).get("schema_name","petrinet")
+			self.schema_name = self.amr.get("header", {}).get("schema_name", "petrinet")
 		self.original_amr = copy.deepcopy(self.amr)
 		if self.amr:
 			await self.load_mira()
@@ -117,7 +117,7 @@ class MiraModelEditContext(BaseContext):
 	async def replace_template_name_request(self, message):
 		content = message.content
 
-		old_name  = content.get("old_name")
+		old_name = content.get("old_name")
 		new_name = content.get("new_name")
 
 		code = self.get_code("replace_template_name", {
@@ -139,8 +139,8 @@ class MiraModelEditContext(BaseContext):
 	async def replace_state_name_request(self, message):
 		content = message.content
 
-		template_name  = content.get("template_name")
-		old_name  = content.get("old_name")
+		template_name = content.get("template_name")
+		old_name = content.get("old_name")
 		new_name = content.get("new_name")
 
 		code = self.get_code("replace_state_name", {
@@ -163,9 +163,9 @@ class MiraModelEditContext(BaseContext):
 	async def add_natural_conversion_template_request(self, message):
 		content = message.content
 
-		subject_name  = content.get("subject_name")
+		subject_name = content.get("subject_name")
 		subject_initial_value = content.get("subject_initial_value")
-		outcome_name  = content.get("outcome_name")
+		outcome_name = content.get("outcome_name")
 		outcome_initial_value = content.get("outcome_initial_value")
 		parameter_name = content.get("parameter_name")
 		parameter_value = content.get("parameter_value")
@@ -201,7 +201,7 @@ class MiraModelEditContext(BaseContext):
 	async def add_natural_production_template_request(self, message):
 		content = message.content
 
-		outcome_name  = content.get("outcome_name")
+		outcome_name = content.get("outcome_name")
 		outcome_initial_value = content.get("outcome_initial_value")
 		parameter_name = content.get("parameter_name")
 		parameter_value = content.get("parameter_value")
@@ -235,7 +235,7 @@ class MiraModelEditContext(BaseContext):
 	async def add_natural_degradation_template_request(self, message):
 		content = message.content
 
-		subject_name  = content.get("subject_name")
+		subject_name = content.get("subject_name")
 		subject_initial_value = content.get("subject_initial_value")
 		parameter_name = content.get("parameter_name")
 		parameter_value = content.get("parameter_value")
@@ -269,9 +269,9 @@ class MiraModelEditContext(BaseContext):
 	async def add_controlled_conversion_template_request(self, message):
 		content = message.content
 
-		subject_name  = content.get("subject_name")
+		subject_name = content.get("subject_name")
 		subject_initial_value = content.get("subject_initial_value")
-		outcome_name  = content.get("outcome_name")
+		outcome_name = content.get("outcome_name")
 		outcome_initial_value = content.get("outcome_initial_value")
 		controller_name = content.get("controller_name")
 		controller_initial_value = content.get("controller_initial_value")
@@ -311,7 +311,7 @@ class MiraModelEditContext(BaseContext):
 	async def add_controlled_production_template_request(self, message):
 		content = message.content
 
-		outcome_name  = content.get("outcome_name")
+		outcome_name = content.get("outcome_name")
 		outcome_initial_value = content.get("outcome_initial_value")
 		controller_name = content.get("controller_name")
 		controller_initial_value = content.get("controller_initial_value")
@@ -349,7 +349,7 @@ class MiraModelEditContext(BaseContext):
 	async def add_controlled_degradation_template_request(self, message):
 		content = message.content
 
-		subject_name  = content.get("subject_name")
+		subject_name = content.get("subject_name")
 		subject_initial_value = content.get("subject_initial_value")
 		controller_name = content.get("controller_name")
 		controller_initial_value = content.get("controller_initial_value")
@@ -407,8 +407,8 @@ class MiraModelEditContext(BaseContext):
 	async def add_parameter_request(self, message):
 		content = message.content
 
-		parameter_id  = content.get("parameter_id")
-		name  = content.get("name")
+		parameter_id = content.get("parameter_id")
+		name = content.get("name")
 		description = content.get("description")
 		value = content.get("value")
 		distribution = content.get("distribution")
@@ -437,8 +437,8 @@ class MiraModelEditContext(BaseContext):
 	async def update_parameter_request(self, message):
 		content = message.content
 
-		updated_id  = content.get("updated_id")
-		replacement_value  = content.get("replacement_value")
+		updated_id = content.get("updated_id")
+		replacement_value = content.get("replacement_value")
 
 		code = self.get_code("update_parameter", {
 			"updated_id": updated_id,
@@ -459,9 +459,9 @@ class MiraModelEditContext(BaseContext):
 	async def add_observable_template_request(self, message):
 		content = message.content
 
-		new_id  = content.get("new_id")
-		new_name  = content.get("new_name")
-		new_expression  = content.get("new_expression")
+		new_id = content.get("new_id")
+		new_name = content.get("new_name")
+		new_expression = content.get("new_expression")
 
 		code = self.get_code("add_observable", {
 			"new_id": new_id,
@@ -483,7 +483,7 @@ class MiraModelEditContext(BaseContext):
 	async def remove_observable_template_request(self, message):
 		content = message.content
 
-		remove_id  = content.get("remove_id")
+		remove_id = content.get("remove_id")
 
 		code = self.get_code("remove_observable", {
 			"remove_id": remove_id
@@ -503,9 +503,9 @@ class MiraModelEditContext(BaseContext):
 	async def replace_ratelaw_request(self, message):
 		content = message.content
 
-		template_name  = content.get("template_name")
-		new_rate_law  = content.get("new_rate_law")
-		
+		template_name = content.get("template_name")
+		new_rate_law = content.get("new_rate_law")
+
 		code = self.get_code("replace_ratelaw", {
 			"template_name": template_name,
 			"new_rate_law": new_rate_law

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_conversion_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_conversion_template.py
@@ -15,7 +15,7 @@ else:
     outcome_concept = Concept(name = "{{ outcome_name }}")
     initials["{{outcome_name }}"] = Initial(concept = outcome_concept, expression = sympy.Float({{outcome_initial_value }}))
 
-for controller_name in "{{ controller_names }}":
+for controller_name in {{ controller_names }}:
     if controller_name in concepts_name_map:
         controller_concept_list.append(concepts_name_map.get(controller_name))
     else:

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_conversion_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_conversion_template.py
@@ -1,0 +1,44 @@
+# Define state variables
+concepts_name_map = model.get_concepts_name_map()
+initials = {}
+controller_concept_list = []
+
+if "{{ subject_name }}" in concepts_name_map:
+    subject_concept = concepts_name_map.get("{{ subject_name }}")
+else:
+    subject_concept = Concept(name = "{{ subject_name }}")
+    initials["{{subject_name }}"] = Initial(concept = subject_concept, expression = sympy.Float({{subject_initial_value }}))
+
+if "{{ outcome_name }}" in concepts_name_map:
+    outcome_concept = concepts_name_map.get("{{ outcome_name }}")
+else:
+    outcome_concept = Concept(name = "{{ outcome_name }}")
+    initials["{{outcome_name }}"] = Initial(concept = outcome_concept, expression = sympy.Float({{outcome_initial_value }}))
+
+for controller_name in "{{ controller_name_list }}":
+    if controller_name in concepts_name_map:
+        controller_concept_list.append(concepts_name_map.get(controller_name))
+    else:
+        controller_concept_list.append(Concept(name = controller_name))
+        initials[controller_name] = Initial(concept = controller_concept, expression = sympy.Float(1))
+
+# Define parameters
+parameters = {}
+if "{{ parameter_name}}" in model.parameters: #note this is checks for paremeter's symbol
+    parameters["{{ parameter_name}}"] = model.parameters.get("{{ parameter_name}}")
+else: 
+    parameters["{{ parameter_name}}"] = Parameter(name = "{{ parameter_name}}", value = {{ parameter_value }}, description = "{{ parameter_description}}")
+
+
+# Add process as new template to the model
+model = model.add_template(
+    template = GroupedControlledConversion(
+        subject = subject_concept,
+        outcome = outcome_concept,
+        controllers = controller_concept_list,
+        rate_law = safe_parse_expr("{{ template_expression }}", local_dict = _clash),
+        name = "{{ template_name }}"
+    ),
+    parameter_mapping = parameters,
+    initial_mapping = initials
+)

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_conversion_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_conversion_template.py
@@ -15,7 +15,7 @@ else:
     outcome_concept = Concept(name = "{{ outcome_name }}")
     initials["{{outcome_name }}"] = Initial(concept = outcome_concept, expression = sympy.Float({{outcome_initial_value }}))
 
-for controller_name in "{{ controller_name_list }}":
+for controller_name in "{{ controller_names }}":
     if controller_name in concepts_name_map:
         controller_concept_list.append(concepts_name_map.get(controller_name))
     else:

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_conversion_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_conversion_template.py
@@ -19,7 +19,8 @@ for controller_name in "{{ controller_names }}":
     if controller_name in concepts_name_map:
         controller_concept_list.append(concepts_name_map.get(controller_name))
     else:
-        controller_concept_list.append(Concept(name = controller_name))
+        controller_concept = Concept(name = controller_name)
+        controller_concept_list.append(controller_concept)
         initials[controller_name] = Initial(concept = controller_concept, expression = sympy.Float(1))
 
 # Define parameters

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_degradation_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_degradation_template.py
@@ -7,7 +7,7 @@ if "{{ subject_name }}" in concepts_name_map:
     subject_concept = concepts_name_map.get("{{ subject_name }}")
 else:
     subject_concept = Concept(name = "{{ subject_name }}")
-    initials["{{subject_name }}"] = Initial(concept = outcome_concept, expression = sympy.Float({{subject_initial_value }}))
+    initials["{{subject_name }}"] = Initial(concept = subject_concept, expression = sympy.Float({{subject_initial_value }}))
 
 for controller_name in "{{ controller_names }}":
     if controller_name in concepts_name_map:

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_degradation_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_degradation_template.py
@@ -9,7 +9,7 @@ else:
     subject_concept = Concept(name = "{{ subject_name }}")
     initials["{{subject_name }}"] = Initial(concept = outcome_concept, expression = sympy.Float({{subject_initial_value }}))
 
-for controller_name in "{{ controller_name_list }}":
+for controller_name in "{{ controller_names }}":
     if controller_name in concepts_name_map:
         controller_concept_list.append(concepts_name_map.get(controller_name))
     else:

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_degradation_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_degradation_template.py
@@ -13,7 +13,8 @@ for controller_name in "{{ controller_names }}":
     if controller_name in concepts_name_map:
         controller_concept_list.append(concepts_name_map.get(controller_name))
     else:
-        controller_concept_list.append(Concept(name = controller_name))
+        controller_concept = Concept(name = controller_name)
+        controller_concept_list.append(controller_concept)
         initials[controller_name] = Initial(concept = controller_concept, expression = sympy.Float(1))
 
 # Define parameters

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_degradation_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_degradation_template.py
@@ -1,0 +1,37 @@
+# Define state variables
+concepts_name_map = model.get_concepts_name_map()
+initials = {}
+controller_concept_list = []
+
+if "{{ subject_name }}" in concepts_name_map:
+    subject_concept = concepts_name_map.get("{{ subject_name }}")
+else:
+    subject_concept = Concept(name = "{{ subject_name }}")
+    initials["{{subject_name }}"] = Initial(concept = outcome_concept, expression = sympy.Float({{subject_initial_value }}))
+
+for controller_name in "{{ controller_name_list }}":
+    if controller_name in concepts_name_map:
+        controller_concept_list.append(concepts_name_map.get(controller_name))
+    else:
+        controller_concept_list.append(Concept(name = controller_name))
+        initials[controller_name] = Initial(concept = controller_concept, expression = sympy.Float(1))
+
+# Define parameters
+parameters = {}
+if "{{ parameter_name}}" in model.parameters: #note this is checks for paremeter's symbol
+    parameters["{{ parameter_name}}"] = model.parameters.get("{{ parameter_name}}")
+else: 
+    parameters["{{ parameter_name}}"] = Parameter(name = "{{ parameter_name}}", value = {{ parameter_value }}, description = "{{ parameter_description}}")
+
+
+# Add process as new template to the model
+model = model.add_template(
+    template = GroupedControlledDegradation(
+        subject = subject_concept,
+        controllers = controller_concept_list,
+        rate_law = safe_parse_expr("{{ template_expression }}", local_dict = _clash),
+        name = "{{ template_name }}"
+    ),
+    parameter_mapping = parameters,
+    initial_mapping = initials
+)

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_degradation_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_degradation_template.py
@@ -9,7 +9,7 @@ else:
     subject_concept = Concept(name = "{{ subject_name }}")
     initials["{{subject_name }}"] = Initial(concept = subject_concept, expression = sympy.Float({{subject_initial_value }}))
 
-for controller_name in "{{ controller_names }}":
+for controller_name in {{ controller_names }}:
     if controller_name in concepts_name_map:
         controller_concept_list.append(concepts_name_map.get(controller_name))
     else:

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_production_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_production_template.py
@@ -9,7 +9,7 @@ else:
     outcome_concept = Concept(name = "{{ outcome_name }}")
     initials["{{outcome_name }}"] = Initial(concept = outcome_concept, expression = sympy.Float({{outcome_initial_value }}))
 
-for controller_name in "{{ controller_names }}":
+for controller_name in {{ controller_names }}:
     if controller_name in concepts_name_map:
         controller_concept_list.append(concepts_name_map.get(controller_name))
     else:

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_production_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_production_template.py
@@ -1,0 +1,37 @@
+# Define state variables
+concepts_name_map = model.get_concepts_name_map()
+initials = {}
+controller_concept_list = []
+
+if "{{ outcome_name }}" in concepts_name_map:
+    outcome_concept = concepts_name_map.get("{{ outcome_name }}")
+else:
+    outcome_concept = Concept(name = "{{ outcome_name }}")
+    initials["{{outcome_name }}"] = Initial(concept = outcome_concept, expression = sympy.Float({{outcome_initial_value }}))
+
+for controller_name in "{{ controller_name_list }}":
+    if controller_name in concepts_name_map:
+        controller_concept_list.append(concepts_name_map.get(controller_name))
+    else:
+        controller_concept_list.append(Concept(name = controller_name))
+        initials[controller_name] = Initial(concept = controller_concept, expression = sympy.Float(1))
+
+# Define parameters
+parameters = {}
+if "{{ parameter_name}}" in model.parameters: #note this is checks for paremeter's symbol
+    parameters["{{ parameter_name}}"] = model.parameters.get("{{ parameter_name}}")
+else: 
+    parameters["{{ parameter_name}}"] = Parameter(name = "{{ parameter_name}}", value = {{ parameter_value }}, description = "{{ parameter_description}}")
+
+
+# Add process as new template to the model
+model = model.add_template(
+    template = GroupedControlledProduction(
+        outcome = outcome_concept,
+        controllers = controller_concept_list,
+        rate_law = safe_parse_expr("{{ template_expression }}", local_dict = _clash),
+        name = "{{ template_name }}"
+    ),
+    parameter_mapping = parameters,
+    initial_mapping = initials
+)

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_production_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_production_template.py
@@ -9,7 +9,7 @@ else:
     outcome_concept = Concept(name = "{{ outcome_name }}")
     initials["{{outcome_name }}"] = Initial(concept = outcome_concept, expression = sympy.Float({{outcome_initial_value }}))
 
-for controller_name in "{{ controller_name_list }}":
+for controller_name in "{{ controller_names }}":
     if controller_name in concepts_name_map:
         controller_concept_list.append(concepts_name_map.get(controller_name))
     else:

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_production_template.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/add_group_controlled_production_template.py
@@ -13,7 +13,8 @@ for controller_name in "{{ controller_names }}":
     if controller_name in concepts_name_map:
         controller_concept_list.append(concepts_name_map.get(controller_name))
     else:
-        controller_concept_list.append(Concept(name = controller_name))
+        controller_concept = Concept(name = controller_name)
+        controller_concept_list.append(controller_concept)
         initials[controller_name] = Initial(concept = controller_concept, expression = sympy.Float(1))
 
 # Define parameters


### PR DESCRIPTION
# Description
Linked to: https://github.com/DARPA-ASKEM/terarium/pull/6193

# Testing (mostly the beaker side of things):
Set up:
- Update local vite config to port 8888
- Build and run beaker
Test:
- Ask the 3 sample questions
- See correct result code for each 
Group-controlled production
`Add a new transition that represents the states "Infected", "Hospitalized" controlling the production of the state "WastewaterViralLoad" with rate law "shed_rate * (Infected + Hospitalized)"`
Group-controlled degradation
`Add a new transition that represents the states "Susceptible", "Infected", "Recovered" controlling the degradation of the state "Hospitalized" with rate law "rec_rate * Hospitalized / (Susceptible + Infected + Recovered)"`
Group-controlled conversion
`Add a new transition that represents the states "Infected", "Recovered" controlling the conversion from the state "Susceptible" to the state "Vaccinated" with rate law "vac_rate / (Infected + Recovered)"`


Run the code for each individually and see the corresponding changes in the output:



