### PR TITLE
Dataset Context: Correction to saving files

### DIFF
--- a/src/askem_beaker/contexts/dataset/procedures/python3/df_save_as.py
+++ b/src/askem_beaker/contexts/dataset/procedures/python3/df_save_as.py
@@ -3,6 +3,7 @@ import tempfile
 
 # Saving as a temporary file instead of a buffer to save memory
 with tempfile.TemporaryFile() as temp_csv_file:
+    {{ var_name|default("df") }}.reset_index(inplace=True)
     {{ var_name|default("df") }}.to_csv(temp_csv_file, index=False, header=True)
     temp_csv_file.seek(0)
     upload_response = requests.put('{{data_url}}', data=temp_csv_file)

--- a/src/askem_beaker/contexts/dataset/procedures/python3/hmi_create_csv_dataset.py
+++ b/src/askem_beaker/contexts/dataset/procedures/python3/hmi_create_csv_dataset.py
@@ -5,7 +5,8 @@ import tempfile
 from json import JSONDecodeError
 
 with tempfile.TemporaryFile() as temp_csv_file:
-    {{ var_name|default("df") }}.to_csv(temp_csv_file, index=True, header=True)
+    {{ var_name|default("df") }}.reset_index(inplace=True)
+    {{ var_name|default("df") }}.to_csv(temp_csv_file, index=False, header=True)
     temp_csv_file.seek(0)
     # Set the HMI_SERVER endpoint
     hmi_server = "{{dataservice_url}}"


### PR DESCRIPTION
# Description:
We want to keep the index column as this is a useful and helpful thing for the user to have when they do operations such as merging or filtering datasets with eachother.
We cannot (and should not) have this as a blank header or our hmiserver will complain about this.
 
fix is for the `hmi_create_csv_dataset` file.
I have duplicated this to the `df_save_as` though I do not see where this `df_save_as` is being used. 


# Video:

https://github.com/user-attachments/assets/bcf94e1d-e647-4b7d-8622-5204d7c53154


