### PR TITLE
Add the missing replace_parameter_name tool to MIRA Model Edit

### DIFF
--- a/src/askem_beaker/contexts/mira_model_edit/agent.py
+++ b/src/askem_beaker/contexts/mira_model_edit/agent.py
@@ -108,6 +108,25 @@ class MiraModelEditAgent(BaseAgent):
         )
 
     @tool()
+    async def replace_parameter_name(self, old_name: str, new_name: str, agent: AgentRef, loop: LoopControllerRef):
+        """
+        This tool is used when a user wants to rename a parameter from an old name to a new name in every expression of the model that it is used.
+
+        Args:
+            old_name (str): The old/existing name of the parameter as it exists in the model before changing.
+            new_name (str): The name to which the parameter should be renamed.
+        """
+        code = agent.context.get_code("replace_parameter_name", {"old_name": old_name, "new_name": new_name})
+        loop.set_state(loop.STOP_SUCCESS)
+        return json.dumps(
+            {
+                "action": "code_cell",
+                "language": "python3",
+                "content": code.strip(),
+            }
+        )
+
+    @tool()
     async def add_observable(self, new_id: str, new_name: str, new_expression: str, agent: AgentRef, loop: LoopControllerRef):
         """
         This tool is used when a user wants to add an observable.
@@ -1105,7 +1124,7 @@ and its structure.
 If you are asked to edit the model, you should try to use other tools for it. You can use the `replace_template_name`, `remove_template`, 
 `replace_state_name`, `add_observable`, `remove_observable`, `add_natural_conversion_template`, `add_controlled_conversion_template`, 
 `add_natural_production_template`, `add_controlled_production_template`, `add_natural_degradation_template`, `add_controlled_degradation_template`, 
-`replace_ratelaw`, `stratify`, `add_parameter`, `change_rate_law_and_add_parameter` tools to help with this.
+`replace_ratelaw`, `stratify`, `replace_parameter_name`, `add_parameter`, `change_rate_law_and_add_parameter` tools to help with this.
 
 Please generate the code as if you were programming inside a Jupyter Notebook and the code is to be executed inside a cell.
 You MUST wrap the code with a line containing three backticks (```) before and after the generated code.

--- a/src/askem_beaker/contexts/mira_model_edit/agent.py
+++ b/src/askem_beaker/contexts/mira_model_edit/agent.py
@@ -759,7 +759,7 @@ class MiraModelEditAgent(BaseAgent):
         )
 
     @tool()
-    async def remove_unsused_parameters(self, 
+    async def remove_unused_parameters(self, 
         agent: AgentRef, loop: LoopControllerRef
     ):
         """
@@ -817,7 +817,7 @@ class MiraModelEditAgent(BaseAgent):
         units_mathml: str
     ):
         """
-        This tool is used when a user wants to replace a ratelaw and add a parameter to a model.
+        This tool is used when a user wants to replace a rate law and add a parameter to a model.
 
         If the parameter is specified as a distribution, the distribution arg should be a dictionary
         object that looks like

--- a/src/askem_beaker/contexts/mira_model_edit/context.py
+++ b/src/askem_beaker/contexts/mira_model_edit/context.py
@@ -160,6 +160,29 @@ class MiraModelEditContext(BaseContext):
 		await self.send_mira_preview_message(parent_header=message.header)
 
 	@intercept()
+	async def replace_parameter_name_request(self, message):
+		content = message.content
+
+		old_name = content.get("old_name")
+		new_name = content.get("new_name")
+
+		code = self.get_code("replace_parameter_name", {
+			"old_name": old_name,
+			"new_name": new_name
+		})
+		result = await self.execute(code)
+		content = {
+			"success": True,
+			"executed_code": result["parent"].content["code"],
+		}
+
+		self.beaker_kernel.send_response(
+			"iopub", "replace_parameter_name_response", content, parent_header=message.header
+		)
+		await self.send_mira_preview_message(parent_header=message.header)
+
+
+	@intercept()
 	async def add_natural_conversion_template_request(self, message):
 		content = message.content
 

--- a/src/askem_beaker/contexts/mira_model_edit/context.py
+++ b/src/askem_beaker/contexts/mira_model_edit/context.py
@@ -434,7 +434,7 @@ class MiraModelEditContext(BaseContext):
 		await self.send_mira_preview_message(parent_header=message.header)
 
 	@intercept()
-	async def remove_unsued_parameters_request(self, message):
+	async def remove_unused_parameters_request(self, message):
 		content = message.content
 
 		code = self.get_code("remove_unused_parameters", {})

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/replace_parameter_name.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/replace_parameter_name.py
@@ -1,0 +1,51 @@
+def replace_parameter_id(model: TemplateModel, old_id: str, new_id: str) -> TemplateModel:
+    """Replace the ID of a parameter
+
+    Given a pair of parameter names (old and new), replace the parameter names from old to new 
+    in every instance (rate law, observable, initial expressions) in the given model.
+
+    Parameters
+    ----------
+    model : JSON
+        The model
+    old_id :
+        The ID of the parameter to replace
+    new_id :
+        The new ID to replace the old ID with
+
+    Returns
+    -------
+    tm: TemplateModel
+        The updated model
+    """
+
+    assert isinstance(model, TemplateModel)
+    tm = model
+
+    if old_id not in tm.parameters:
+        raise ValueError(f"Parameter with ID {old_id} not found in model.")
+    
+    for template in tm.templates:
+        if template.rate_law:
+            template.rate_law = SympyExprStr(
+                template.rate_law.args[0].subs(sympy.Symbol(old_id),
+                                               sympy.Symbol(new_id)))
+            
+    for observable in tm.observables.values():
+        observable.expression = SympyExprStr(
+            observable.expression.args[0].subs(sympy.Symbol(old_id),
+                                               sympy.Symbol(new_id)))
+        
+    for key, param in copy.deepcopy(tm.parameters).items():
+        if param.name == old_id:
+            popped_param = tm.parameters.pop(param.name)
+            popped_param.name = new_id
+            tm.parameters[new_id] = popped_param
+
+    for initial in tm.initials.values():
+        if initial.expression:
+            initial.substitute_parameter(old_id, sympy.Symbol(new_id))
+
+    return tm
+
+model = replace_parameter_id(model, '{{ old_name }}', '{{ new_name }}')

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/replace_state_name.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/replace_state_name.py
@@ -1,4 +1,4 @@
-def replace_state_name(model , template_name: str, old_name: str, new_name: str) -> TemplateModel:
+def replace_state_name(model: TemplateModel, template_name: str, old_name: str, new_name: str) -> TemplateModel:
 
     """
     Given a TemplateModel model and the old & new name of a state/concept therein, 


### PR DESCRIPTION
Handles this issue #188. Requested by Zach from MITRE. 