### PR TITLE
factor parameter when doing stratification

### DIFF
--- a/src/askem_beaker/contexts/mira_model_edit/agent.py
+++ b/src/askem_beaker/contexts/mira_model_edit/agent.py
@@ -645,7 +645,7 @@ class MiraModelEditAgent(BaseAgent):
         concepts_to_preserve: Optional[list[str]] = None,
         params_to_stratify: Optional[list[str]] = None,
         params_to_preserve: Optional[list[str]] = None,
-		add_param_factor = Optional[bool] = True
+        add_param_factor = Optional[bool] = True
     ):
         """
         This tool is used when a user wants to stratify a model.

--- a/src/askem_beaker/contexts/mira_model_edit/agent.py
+++ b/src/askem_beaker/contexts/mira_model_edit/agent.py
@@ -644,7 +644,8 @@ class MiraModelEditAgent(BaseAgent):
         concepts_to_stratify: Optional[list[str]] = None,
         concepts_to_preserve: Optional[list[str]] = None,
         params_to_stratify: Optional[list[str]] = None,
-        params_to_preserve: Optional[list[str]] = None
+        params_to_preserve: Optional[list[str]] = None,
+		add_param_factor = Optional[bool] = True
     ):
         """
         This tool is used when a user wants to stratify a model.
@@ -715,6 +716,8 @@ class MiraModelEditAgent(BaseAgent):
                 This is a list of the parameters in the model that must not be stratified.
                 For example, given a model with parameters ("beta", "gamma") and a request like "preserve" or "do not stratify" the "beta" parameter, the value of this argument should be ["beta"].
                 If the request does not specify any parameter to not be stratified or preserved in particular, then the value of this argument should default to None.
+            add_param_factor (Optional):
+                Whether to add new proxy-parameters when stratification involve parameters. For example instead of "beta_young" and "beta_old", it will be "beta * f_young" and "beta * f_old"
         """
 
         code = agent.context.get_code("stratify", {
@@ -727,7 +730,8 @@ class MiraModelEditAgent(BaseAgent):
             "concepts_to_stratify": concepts_to_stratify,
             "concepts_to_preserve": concepts_to_preserve,
             "params_to_stratify": params_to_stratify,
-            "params_to_preserve": params_to_preserve
+            "params_to_preserve": params_to_preserve,
+            "add_param_factor": add_param_factor
         })
         loop.set_state(loop.STOP_SUCCESS)
         return json.dumps(

--- a/src/askem_beaker/contexts/mira_model_edit/agent.py
+++ b/src/askem_beaker/contexts/mira_model_edit/agent.py
@@ -645,7 +645,7 @@ class MiraModelEditAgent(BaseAgent):
         concepts_to_preserve: Optional[list[str]] = None,
         params_to_stratify: Optional[list[str]] = None,
         params_to_preserve: Optional[list[str]] = None,
-        add_param_factor = Optional[bool] = True
+        add_param_factor: Optional[bool] = True
     ):
         """
         This tool is used when a user wants to stratify a model.

--- a/src/askem_beaker/contexts/mira_model_edit/context.py
+++ b/src/askem_beaker/contexts/mira_model_edit/context.py
@@ -590,6 +590,8 @@ class MiraModelEditContext(BaseContext):
 		cartesian_control = content.get("cartesian_control")
 		structure = content.get("structure")
 		add_param_factor = content.get("add_param_factor")
+		if add_param_factor is None:
+			add_param_factor = True
 
 		stratify_code = self.get_code("stratify", {
 			"key": key,

--- a/src/askem_beaker/contexts/mira_model_edit/context.py
+++ b/src/askem_beaker/contexts/mira_model_edit/context.py
@@ -589,6 +589,7 @@ class MiraModelEditContext(BaseContext):
 		params_to_preserve = content.get("params_to_preserve")
 		cartesian_control = content.get("cartesian_control")
 		structure = content.get("structure")
+		add_param_factor = content.get("add_param_factor")
 
 		stratify_code = self.get_code("stratify", {
 			"key": key,
@@ -598,7 +599,8 @@ class MiraModelEditContext(BaseContext):
 			"params_to_stratify": params_to_stratify,
 			"params_to_preserve": params_to_preserve,
 			"cartesian_control": cartesian_control,
-			"structure": structure
+			"structure": structure,
+			"add_param_factor": add_param_factor
 		})
 		stratify_result = await self.execute(stratify_code)
 

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/stratify.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/stratify.py
@@ -15,14 +15,14 @@ model = stratify(
     param_renaming_uses_strata_names = True
 )
 
-add_param_factor = {{ add_param_factor | True }}
+add_param_factor = {{ add_param_factor|default(True) }}
 
 # FIXME: need to juggle inclusive vs exclusive
 params_to_stratify= {{ params_to_stratify|default(None) }}
 
 model_ = copy.deepcopy(model)
 
-if add_param_factor:
+if add_param_factor == True:
     new_params = {param: 'f_' + param for param in params_to_stratify}
     for param, factor in new_params.items():
 

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/stratify.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/stratify.py
@@ -1,38 +1,20 @@
 import copy
 
-model = stratify(
-    template_model=model,
-    key= "{{ key }}",
-    strata={{ strata }},
-    structure= {{ structure|default(None) }},
-    directed={{ directed|default(False) }},
-    cartesian_control={{ cartesian_control|default(False) }},
-    modify_names={{ modify_names|default(True) }},
-    concepts_to_stratify={{ concepts_to_stratify|default(None) }}, #If none given, will stratify all concepts.
-    concepts_to_preserve={{ concepts_to_preserve|default(None) }}, #If none given, will stratify all concepts.
-    params_to_stratify= {{ params_to_stratify|default(None) }}, #If none given, will stratify all parameters.
-    params_to_preserve= {{ params_to_preserve|default(None) }}, #If none given, will stratify all parameters.
-    param_renaming_uses_strata_names = True
-)
-
 add_param_factor = {{ add_param_factor|default(True) }}
-
-# FIXME: need to juggle inclusive vs exclusive
 params_to_stratify= {{ params_to_stratify|default(None) }}
 
-model_ = copy.deepcopy(model)
+model_to_stratify = copy.deepcopy(model)
 
 if add_param_factor == True:
     new_params = {param: 'f_' + param for param in params_to_stratify}
     for param, factor in new_params.items():
-
         # In case of parameter name clash
-        while factor in model_.parameters.keys():
+        while factor in model_to_stratify.parameters.keys():
             factor += '_0'
         new_params[param] = factor
 
         # Replace 'param' with 'param * factor' in all rate laws
-        for template in model_.templates:
+        for template in model_to_stratify.templates:
             template.rate_law = SympyExprStr(
                 template.rate_law.args[0].subs(
                     sympy.Symbol(param),
@@ -41,11 +23,29 @@ if add_param_factor == True:
             )
 
         # Add the factor as a new model parameter
-        model_.add_parameter(
+        model_to_stratify.add_parameter(
             parameter_id = factor,
             name = factor,
             description = f'Stratification factor of the parameter {param}.',
             value = 1.0
         )
 
-model = model_
+    # Replace params with factored parameters
+    params_to_stratify = list(new_params.values())
+
+
+
+model = stratify(
+    template_model=model_to_stratify,
+    key= "{{ key }}",
+    strata={{ strata }},
+    structure= {{ structure|default(None) }},
+    directed={{ directed|default(False) }},
+    cartesian_control={{ cartesian_control|default(False) }},
+    modify_names={{ modify_names|default(True) }},
+    concepts_to_stratify={{ concepts_to_stratify|default(None) }}, #If none given, will stratify all concepts.
+    concepts_to_preserve={{ concepts_to_preserve|default(None) }}, #If none given, will stratify all concepts.
+    params_to_stratify=params_to_stratify,
+    params_to_preserve= {{ params_to_preserve|default(None) }}, #If none given, will stratify all parameters.
+    param_renaming_uses_strata_names = True
+)

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/stratify.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/stratify.py
@@ -1,3 +1,5 @@
+import copy
+
 model = stratify(
     template_model=model,
     key= "{{ key }}",
@@ -12,3 +14,38 @@ model = stratify(
     params_to_preserve= {{ params_to_preserve|default(None) }}, #If none given, will stratify all parameters.
     param_renaming_uses_strata_names = True
 )
+
+add_param_factor = {{ add_param_factor | True }}
+
+# FIXME: need to juggle inclusive vs exclusive
+params_to_stratify= {{ params_to_stratify|default(None) }}
+
+model_ = copy.deepcopy(model)
+
+if add_param_factor:
+    new_params = {param: 'f_' + param for param in params_to_stratify}
+    for param, factor in new_params.items():
+
+        # In case of parameter name clash
+        while factor in model_.parameters.keys():
+            factor += '_0'
+        new_params[param] = factor
+
+        # Replace 'param' with 'param * factor' in all rate laws
+        for template in model_.templates:
+            template.rate_law = SympyExprStr(
+                template.rate_law.args[0].subs(
+                    sympy.Symbol(param),
+                    sympy.Symbol(param) * sympy.Symbol(factor)
+                )
+            )
+
+        # Add the factor as a new model parameter
+        model_.add_parameter(
+            parameter_id = factor,
+            name = factor,
+            description = f'Stratification factor of the parameter {param}.',
+            value = 1.0
+        )
+
+model = model_


### PR DESCRIPTION
Request from Nelson to introduce proxy factored parameters when performing stratification. For example, if we stratify by age groups young/old and the parameter beta is included, we would get
- beta_young, beta_old

With factored parameters, beta will not be stratified per se, but instead we will have
- beta * f_beta_young, beta * f_beta_old

Where the `f_beta_*` are the newly introduced factored parameters