### PR TITLE
rename reset_request/reset_response

### DIFF
--- a/src/askem_beaker/contexts/mira_model_edit/context.py
+++ b/src/askem_beaker/contexts/mira_model_edit/context.py
@@ -94,7 +94,7 @@ class MiraModelEditContext(BaseContext):
 			raise
 
 	@intercept()
-	async def reset_request(self, message):
+	async def reset_mira_request(self, message):
 		content = message.content
 
 		model_name = content.get("model_name", "model")
@@ -109,7 +109,7 @@ class MiraModelEditContext(BaseContext):
 		}
 
 		self.beaker_kernel.send_response(
-				"iopub", "reset_response", content, parent_header=message.header
+				"iopub", "reset_mira_response", content, parent_header=message.header
 		)
 		await self.send_mira_preview_message(parent_header=message.header)
 


### PR DESCRIPTION
### Summary
Matt mentioned that reset_request/reset_response are used internally at the kernel level. So this just renames the two to avoid collision/confusion.


