### PR TITLE
Improve stratification factor option

### DIFF
--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/stratify.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/stratify.py
@@ -49,3 +49,8 @@ model = stratify(
     params_to_preserve= {{ params_to_preserve|default(None) }}, #If none given, will stratify all parameters.
     param_renaming_uses_strata_names = True
 )
+
+# Remove any leftover parameter
+for __, factor in new_params.items():
+    if factor in model.parameters.keys():
+        __ = model.parameters.pop(factor)

--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/stratify.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/stratify.py
@@ -6,7 +6,7 @@ params_to_stratify= {{ params_to_stratify|default(None) }}
 model_to_stratify = copy.deepcopy(model)
 
 if add_param_factor == True:
-    new_params = {param: 'f_' + param for param in params_to_stratify}
+    new_params = {param: 'f' + param for param in params_to_stratify}
     for param, factor in new_params.items():
         # In case of parameter name clash
         while factor in model_to_stratify.parameters.keys():


### PR DESCRIPTION
- [X] Change the default name of stratification factors from `f_<param>` to just `f<param>` to enable better grouping in the Parameters table
- [x] Remove leftover `f<param>` after stratification (should be automatically done by MIRA but nonetheless)