### PR TITLE
Fix: Stratify code new_params definition

### DIFF
--- a/src/askem_beaker/contexts/mira_model_edit/procedures/python3/stratify.py
+++ b/src/askem_beaker/contexts/mira_model_edit/procedures/python3/stratify.py
@@ -4,6 +4,7 @@ add_param_factor = {{ add_param_factor|default(True) }}
 params_to_stratify= {{ params_to_stratify|default(None) }}
 
 model_to_stratify = copy.deepcopy(model)
+new_params = {}
 
 if add_param_factor == True:
     new_params = {param: 'f' + param for param in params_to_stratify}


### PR DESCRIPTION
# Issue:
new_params is only defined within the `if add_param_factor == True:`. This means when `if add_param_factor == False;` it is undefined and the reference of it at the end would break. 
```
# Remove any leftover parameter
for __, factor in new_params.items():
```

# Solution:
Define it as empty at the top to allow it to be later referenced safely.
