### PR TITLE
Install pyobo from github since pypi version is out of date and broken

### DIFF
--- a/Dockerfile.light
+++ b/Dockerfile.light
@@ -72,6 +72,11 @@ COPY --chown=1000:1000 pyproject.toml README.md hatch_build.py /home/jupyter/ask
 RUN mkdir -p /home/jupyter/askem_beaker/src/askem_beaker && touch /home/jupyter/askem_beaker/src/askem_beaker/__init__.py
 RUN pip install --no-cache-dir --upgrade -e /home/jupyter/askem_beaker
 
+# uninstall pyobo
+RUN pip uninstall pyobo -y
+# Install pyobo from Github (https://github.com/biopragmatics/pyobo)
+RUN pip install git+https://github.com/biopragmatics/pyobo.git
+
 # Bootstrap MIRA runtime dependencies, these are lazily downloaded but we will get them ahead of time to avoid quirky
 # interfacing issues across jupyter messaging
 RUN python -c "from pyobo import Term, Reference, Obo"


### PR DESCRIPTION
Fix to deal with the fact that `pyobo` is in flux and might not get a release on `pypi` for a while